### PR TITLE
Adjust PageViewController Scope

### DIFF
--- a/Sources/Pageboy/PageboyViewController.swift
+++ b/Sources/Pageboy/PageboyViewController.swift
@@ -46,7 +46,7 @@ open class PageboyViewController: UIViewController {
     
     // MARK: Properties
     
-    internal var pageViewController: UIPageViewController?
+    public var pageViewController: UIPageViewController?
     internal var previousPagePosition: CGFloat?
     internal var expectedTransitionIndex: PageIndex?
 


### PR DESCRIPTION
The contained PageViewController may, in some cases, need to be accessible externally. In my example, I need to mask the edges of the scroll view for a particular layout. Since this is an edge case that's layout-dependent, doesn't really make sense to add a full masking capability to Pageboy; rather, the simple solution is to provide access to the underlying controller.